### PR TITLE
Getting version from homebrew formulae

### DIFF
--- a/install
+++ b/install
@@ -3,26 +3,22 @@ set -eo pipefail
 DOWNLOAD_URL="https://github.com/getantibody/antibody/releases/download"
 test -z "$TMPDIR" && TMPDIR="$(mktemp -d)"
 
-# shellcheck disable=SC2139
-test -n "$GITHUB_TOKEN" &&
-  alias curl="curl -H 'Authorization: Bearer $GITHUB_TOKEN'"
-
 last_version() {
-  curl -s https://api.github.com/repos/getantibody/antibody/releases |
-    grep tag_name |
-    head -n1 |
-    cut -f4 -d '"'
+  curl -s https://raw.githubusercontent.com/getantibody/homebrew-antibody/master/antibody.rb |
+    grep version |
+    cut -f2 -d '"'
 }
 
 download() {
   version="$(last_version)" || true
   test -z "$version" && {
-    echo "Unable to get antibody version through GitHub API."
+    echo "Unable to get antibody version."
     exit 1
   }
   echo "Downloading antibody $version for $(uname -s)_$(uname -m)..."
-  command curl -sL -o /tmp/antibody.tar.gz \
-    "$DOWNLOAD_URL/$version/antibody_$(uname -s)_$(uname -m).tar.gz"
+  rm -f /tmp/antibody.tar.gz
+  curl -L -o /tmp/antibody.tar.gz \
+    "$DOWNLOAD_URL/v$version/antibody_$(uname -s)_$(uname -m).tar.gz"
 }
 
 extract() {


### PR DESCRIPTION
getting it via API is too unstable, broken builds everywhere.

I need to update the formuae anyway, so, let's get the version from
there.
